### PR TITLE
Fixes server NPC's so they update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Get the amount of players on a world or on a server with SlapperPlayerCount!
 - Fix server player count NPC's not updating their name tag.
 - Cleanup the server query task code.
 
-**Important:** 3.0.0 brings support for [PocketMine-MP API 4](), dropping API 3 support. Check out the plugin by clicking [here](http://poggit.pmmp.io/p/WorldPlayerCount/)
+**Important:** 3.0.0 brings support for [PocketMine-MP API 4](https://github.com/pmmp/PocketMine-MP/releases/tag/4.0.0), dropping API 3 support. Check out the plugin by clicking [here](http://poggit.pmmp.io/p/WorldPlayerCount/)
 ### 3.0.0
 - PocketMine-MP API v4 support (drops API 3).
 - Rewrites a large amount of code to de-bloat the main plugin class by keeping all data loading/saving in a separate utility class.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # SlapperPlayerCount
 Get the amount of players on a world or on a server with SlapperPlayerCount!
 
-**Important:** 2.1.2 brings support for WPC support, which you can either choose to enable or disable in the config. WPC has more features for world querying, check out the plugin by clicking [here](http://poggit.pmmp.io/p/WorldPlayerCount/)
 ## Updates
+### 3.1.0
+- Fix server player count NPC's not updating their name tag.
+- Cleanup the server query task code.
+
+**Important:** 3.0.0 brings support for [PocketMine-MP API 4](), dropping API 3 support. Check out the plugin by clicking [here](http://poggit.pmmp.io/p/WorldPlayerCount/)
+### 3.0.0
+- PocketMine-MP API v4 support (drops API 3).
+- Rewrites a large amount of code to de-bloat the main plugin class by keeping all data loading/saving in a separate utility class.
+- Removes automatic Slapper plugin installation.
+
+**Important:** 2.1.2 brings support for WPC support, which you can either choose to enable or disable in the config. WPC has more features for world querying, check out the plugin by clicking [here](http://poggit.pmmp.io/p/WorldPlayerCount/)
 ### 2.1.2
 - Add WorldPlayerCount support because it's unfair not giving people options.
 - Add version to config

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 ---
 name: SlapperPlayerCount
-version: 3.0.0
+version: 3.1.0
 main: ethaniccc\SlapperPlayerCount\Main
 description: Get the amount of players on a world or server using Slapper!
 api: 4.0.0

--- a/src/ethaniccc/SlapperPlayerCount/Main.php
+++ b/src/ethaniccc/SlapperPlayerCount/Main.php
@@ -95,7 +95,7 @@ class Main extends PluginBase implements Listener {
 	 * @param array|null                $data
 	 */
 	public function updateSlapperEntity(Entity $entity, ?array &$data = null) : void {
-		$countInfo = $this->trackedSlappers[$entity->getId()];
+		$countInfo = $this->trackedSlappers[$entity->getId()] ?? null;
 		if($countInfo === null) {
 			return;
 		}

--- a/src/ethaniccc/SlapperPlayerCount/Main.php
+++ b/src/ethaniccc/SlapperPlayerCount/Main.php
@@ -42,9 +42,10 @@ class Main extends PluginBase implements Listener {
 				$this->updateSlapper();
 			}), $updateTicks);
 
-			$this->getServer()->getPluginManager()->registerEvents($this, $this);
+			$server = $this->getServer();
+			$server->getPluginManager()->registerEvents($this, $this);
 
-			foreach($this->getServer()->getWorldManager()->getWorlds() as $world) {
+			foreach($server->getWorldManager()->getWorlds() as $world) {
 				foreach($world->getEntities() as $entity) {
 					if(!($entity instanceof SlapperEntity)) {
 						continue;
@@ -54,13 +55,9 @@ class Main extends PluginBase implements Listener {
 				}
 			}
 
-			$wpc = $this->getServer()->getPluginManager()->getPlugin("WorldPlayerCount");
-			if($this->getConfig()->get("wpc_support") == false) {
-				if($wpc !== null && !$wpc->isDisabled()) {
-					$this->getServer()->getPluginManager()->disablePlugin($wpc);
-				}
-			} elseif($this->getConfig()->get("wpc_support") == true) {
-				if($wpc == null || $wpc->isDisabled()) {
+			$wpc = $server->getPluginManager()->getPlugin("WorldPlayerCount");
+			if($this->getConfig()->get("wpc_support") === true) {
+				if($wpc === null || !$server->getPluginManager()->isPluginEnabled($wpc)) {
 					$this->getLogger()->debug("WorldPlayerCount support is enabled, but does not exist (or is disabled) on your server.");
 				} else {
 					$this->getLogger()->debug("WorldPlayerCount support is enabled, and world querying will depend on it.");

--- a/src/ethaniccc/SlapperPlayerCount/Main.php
+++ b/src/ethaniccc/SlapperPlayerCount/Main.php
@@ -38,7 +38,7 @@ class Main extends PluginBase implements Listener {
 			$updateTicks = 100;
 		}
 		$this->getScheduler()->scheduleDelayedTask(new ClosureTask(function() use ($updateTicks) : void {
-			$this->getScheduler()->scheduleRepeatingTask(new ClosureTask(function() use ($updateTicks) : void {
+			$this->getScheduler()->scheduleRepeatingTask(new ClosureTask(function() : void {
 				$this->updateSlapper();
 			}), $updateTicks);
 

--- a/src/ethaniccc/SlapperPlayerCount/Main.php
+++ b/src/ethaniccc/SlapperPlayerCount/Main.php
@@ -70,12 +70,7 @@ class Main extends PluginBase implements Listener {
 	public function updateSlapper() : void {
 		$data = [];
 		foreach($this->trackedSlappers as $id => $countInfo) {
-			$world = $countInfo->getWorld();
-			if($world === null) {
-				continue;
-			}
-
-			$entity = $world->getEntity($id);
+			$entity = $countInfo->getWorld()->getEntity($id);
 			if($entity === null) {
 				continue;
 			}

--- a/src/ethaniccc/SlapperPlayerCount/SlapperPlayerCountEntityInfo.php
+++ b/src/ethaniccc/SlapperPlayerCount/SlapperPlayerCountEntityInfo.php
@@ -58,8 +58,9 @@ class SlapperPlayerCountEntityInfo {
 	/**
 	 * Construct a new world player count instance.
 	 *
+	 * @param \pocketmine\world\World        $world
 	 * @param string                         $nameTemplate
-	 * @param \pocketmine\world\World|string $world
+	 * @param \pocketmine\world\World|string $targetWorld
 	 *
 	 * @return static|null
 	 */

--- a/src/ethaniccc/SlapperPlayerCount/SlapperPlayerCountEntityInfo.php
+++ b/src/ethaniccc/SlapperPlayerCount/SlapperPlayerCountEntityInfo.php
@@ -22,25 +22,75 @@ use pocketmine\world\World;
 
 class SlapperPlayerCountEntityInfo {
 
-	private ?string $ip = null;
-	private ?int $port = null;
-	private ?World $world = null;
-	private ?string $worldName = null;
 	public const TYPE_SERVER = 0;
 	public const TYPE_WORLD = 1;
 
-	private function __construct(private int $type, private string $nameTemplate) {
+	/**
+	 * Construct a new server player count instance.
+	 *
+	 * @param \pocketmine\world\World $world
+	 * @param string                  $nameTemplate
+	 * @param string                  $ip
+	 * @param int|string              $port
+	 *
+	 * @return static|null
+	 */
+	public static function server(World $world, string $nameTemplate, string $ip, int|string $port) : ?self {
+		if(is_string($port)) {
+			$port = (int)$port;
+			if($port === 0) {
+				return null;
+			}
+		}
 
+		$new = new self(self::TYPE_SERVER, $world, $nameTemplate);
+
+		if(!(self::isValidIP($ip) or self::is_valid_domain_name($ip) or self::isValidPort($port))) {
+			return null;
+		}
+
+		$new->ip = $ip;
+		$new->port = $port;
+
+		return $new;
+	}
+
+	/**
+	 * Construct a new world player count instance.
+	 *
+	 * @param string                         $nameTemplate
+	 * @param \pocketmine\world\World|string $world
+	 *
+	 * @return static|null
+	 */
+	public static function world(World $world, string $nameTemplate, World|string $targetWorld) : ?self {
+		$new = new self(self::TYPE_WORLD, $world, $nameTemplate);
+
+		if($targetWorld instanceof World) {
+			$new->targetWorld = $targetWorld;
+		} else {
+			$targetWorld = Server::getInstance()->getWorldManager()->getWorldByName($targetWorld);
+			if(!($targetWorld instanceof World)) {
+				return null;
+			}
+
+			$new->targetWorld = $targetWorld;
+		}
+
+		$new->targetWorldName = $targetWorld->getFolderName();
+
+		return $new;
 	}
 
 	/**
 	 * Construct a new player count instance from a name tag.
 	 *
-	 * @param string $nameTag
+	 * @param \pocketmine\world\World $world
+	 * @param string                  $nameTag
 	 *
 	 * @return static|null
 	 */
-	public static function fromNameTag(string $nameTag) : ?self {
+	public static function fromNameTag(World $world, string $nameTag) : ?self {
 		$lines = explode("\n", $nameTag);
 		foreach($lines as $line) {
 			$parts = explode(':', $line);
@@ -56,91 +106,21 @@ class SlapperPlayerCountEntityInfo {
 					return null;
 				}
 
-				return self::server($nameTag, $ip, $port);
+				return self::server($world, $nameTag, $ip, $port);
 			} elseif($type === 'world') {
 				$name = $parts[1] ?? null;
 				if($name === null) {
 					return null;
 				}
 
-				return self::world($nameTag, $name);
+				return self::world($world, $nameTag, $name);
 			}
 		}
 
 		return null;
 	}
 
-	/**
-	 * Construct a new server player count instance.
-	 *
-	 * @param string $nameTemplate
-	 * @param string $ip
-	 * @param int    $port
-	 *
-	 * @return static|null
-	 */
-	public static function server(string $nameTemplate, string $ip, int|string $port) : ?self {
-		if(is_string($port)) {
-			$port = (int)$port;
-			if($port === 0) {
-				return null;
-			}
-		}
-
-		$new = new self(self::TYPE_SERVER, $nameTemplate);
-
-		if(!(self::isValidIP($ip) or self::is_valid_domain_name($ip) or self::isValidPort($port))) {
-			return null;
-		}
-
-		$new->ip = $ip;
-		$new->port = $port;
-
-		return $new;
-	}
-
-	protected static function isValidIP(string $ip) : bool {
-		return (preg_match('/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d{1,5})/', $ip) !== false);
-	}
-
-	protected static function is_valid_domain_name(string $domain_name) : bool {
-		return (preg_match('/([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*:(\d{1,5})/i', $domain_name) //valid chars check
-			and preg_match('/.{1,253}/', $domain_name) //overall length check
-			and preg_match('/[^\.]{1,63}(\.[^\.]{1,63})*/', $domain_name)); //length of each label
-	}
-
-	protected static function isValidPort(int $port) : bool {
-		return ($port >= 1 and $port <= 65535);
-	}
-
-	/**
-	 * Construct a new world player count instance.
-	 *
-	 * @param string                         $nameTemplate
-	 * @param \pocketmine\world\World|string $world
-	 *
-	 * @return static|null
-	 */
-	public static function world(string $nameTemplate, World|string $world) : ?self {
-		$new = new self(self::TYPE_WORLD, $nameTemplate);
-
-		if($world instanceof World) {
-			$new->world = $world;
-		} else {
-			$world = Server::getInstance()->getWorldManager()->getWorldByName($world);
-			if(!($world instanceof World)) {
-				return null;
-			}
-
-			$new->world = $world;
-		}
-
-		$new->worldName = $new->world->getFolderName();
-
-		return $new;
-	}
-
-	public static function fromNbt(CompoundTag $nbt) : ?self {
+	public static function fromNbt(World $world, CompoundTag $nbt) : ?self {
 		$tag = $nbt->getTag("SlapperPlayerCount");
 		if(!($tag instanceof CompoundTag)) {
 			return null;
@@ -159,59 +139,61 @@ class SlapperPlayerCountEntityInfo {
 				return null;
 			}
 
-			return self::server($nameTemplate, $ip, $port);
+			return self::server($world, $nameTemplate, $ip, $port);
 		} elseif($type === self::TYPE_WORLD) {
 			$worldName = $tag->getString("World");
 			$world = Server::getInstance()->getWorldManager()->getWorldByName($worldName);
 			if($world === null) {
 				return null;
 			}
-			return self::world($nameTemplate, $world);
+			return self::world($world, $nameTemplate, $world);
 		}
 
 		return null;
 	}
 
-	/**
-	 * @return int
-	 */
+	private string $worldName;
+
+	private ?string $ip = null;
+	private ?int $port = null;
+
+	private ?World $targetWorld = null;
+	private ?string $targetWorldName = null;
+
+	private function __construct(private int $type, private World $world, private string $nameTemplate) {
+		$this->worldName = $world->getFolderName();
+	}
+
 	public function getType() : int {
 		return $this->type;
 	}
 
-	/**
-	 * @return string
-	 */
+	public function getWorld() : World {
+		return $this->world;
+	}
+
+	public function getWorldName() : string {
+		return $this->worldName;
+	}
+
 	public function getNameTemplate() : string {
 		return $this->nameTemplate;
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function getIp() : ?string {
 		return $this->ip;
 	}
 
-	/**
-	 * @return int|null
-	 */
 	public function getPort() : ?int {
 		return $this->port;
 	}
 
-	/**
-	 * @return \pocketmine\world\World|null
-	 */
-	public function getWorld() : ?World {
-		return $this->world;
+	public function getTargetWorld() : ?World {
+		return $this->targetWorld;
 	}
 
-	/**
-	 * @return string|null
-	 */
-	public function getWorldName() : ?string {
-		return $this->worldName;
+	public function getTargetWorldName() : ?string {
+		return $this->targetWorldName;
 	}
 
 	/**
@@ -227,10 +209,24 @@ class SlapperPlayerCountEntityInfo {
 			$tag->setString("Ip", $this->ip);
 			$tag->setInt("Port", $this->port);
 		} elseif($this->type === self::TYPE_WORLD) {
-			$tag->setString("World", $this->worldName);
+			$tag->setString("World", $this->targetWorldName);
 		}
 
 		$nbt->setTag("SlapperPlayerCount", $tag);
+	}
+
+	protected static function isValidIP(string $ip) : bool {
+		return (preg_match('/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d{1,5})/', $ip) !== false);
+	}
+
+	protected static function is_valid_domain_name(string $domain_name) : bool {
+		return (preg_match('/([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*:(\d{1,5})/i', $domain_name) //valid chars check
+			and preg_match('/.{1,253}/', $domain_name) //overall length check
+			and preg_match('/[^\.]{1,63}(\.[^\.]{1,63})*/', $domain_name)); //length of each label
+	}
+
+	protected static function isValidPort(int $port) : bool {
+		return ($port >= 1 and $port <= 65535);
 	}
 
 }

--- a/src/ethaniccc/SlapperPlayerCount/Tasks/QueryServer.php
+++ b/src/ethaniccc/SlapperPlayerCount/Tasks/QueryServer.php
@@ -39,24 +39,28 @@ class QueryServer extends AsyncTask {
 			$level = $server->getWorldManager()->getWorldByName($data["entity"]["level"]);
 			if($level === null) {
 				$server->getLogger()->debug("Unexpected null level ($key)");
-			} else {
-				$entity = $level->getEntity($data["entity"]["id"]);
-				if($entity !== null) {
-					if($data["online"]) {
-						$lines = explode("\n", $entity->getNameTag());
-						$base = $this->onlineMsg;
-						$message = str_replace(["{online}", "{max_online}"], [$data["data"]["online"], $data["data"]["maxOnline"]], $base);
-						$lines[1] = $message;
-						$nametag = implode("\n", $lines);
-						$entity->setNameTag($nametag);
-					} else {
-						$lines = explode("\n", $entity->getNameTag());
-						$lines[1] = $this->offlineMsg;
-						$nametag = implode("\n", $lines);
-						$entity->setNameTag($nametag);
-					}
-				}
+				continue;
 			}
+
+			$entity = $level->getEntity($data["entity"]["id"]);
+			if($entity === null) {
+				$server->getLogger()->debug("Unexpected null entity ($key)");
+				continue;
+			}
+
+			$lines = explode("\n", $entity->getNameTag());
+			if($data['online'] === false) {
+				$lines[1] = $this->offlineMsg;
+				$nametag = implode("\n", $lines);
+				$entity->setNameTag($nametag);
+				continue;
+			}
+
+			$base = $this->onlineMsg;
+			$message = str_replace(["{online}", "{max_online}"], [$data["data"]["online"], $data["data"]["maxOnline"]], $base);
+			$lines[1] = $message;
+			$nametag = implode("\n", $lines);
+			$entity->setNameTag($nametag);
 		}
 	}
 


### PR DESCRIPTION
* Track NPC/slapper world no matter the type
* Renamed SlapperPlayerCountEntityInfo::$world to SlapperPlayerCountEntityInfo::$targetWorld for world NPC's (all NPC's have their world tracked now)
* Fixes broken condition that could cause server updates to always think they're batched and not run the async-task
* QueryServer: cleanup onCompletion() callback
* bump to v3.1.0